### PR TITLE
Handle message types other than MSG_REQ

### DIFF
--- a/MegaCAN.cpp
+++ b/MegaCAN.cpp
@@ -12,7 +12,7 @@ void MegaCAN::processMSreq(uint32_t msgCore, const uint8_t msgData[8], MegaCAN_m
   msg.core.msgType = (msgCore & ~(0b11111111111111000111111111111111)) >> 15; //set msgType to bits 17-15 of msgCore
   msg.core.toOffset =  (msgCore & ~(0b11100000000000111111111111111111)) >> 18; //set toOffset to bits 28-18 of msgCore
 	
-  msg.rawData = msgData;	// Don't clobber data for msgType != 1
+  for (uint8_t i = 0; i < 8; i++) msg.rawData[i] = msgData[i];	// Don't clobber data for msgType != 1
 
   // Process message data - Only valid if msgType is 1.
   msg.data.request.varBlk = msgData[0];

--- a/MegaCAN.cpp
+++ b/MegaCAN.cpp
@@ -3,7 +3,7 @@
 
 MegaCAN::MegaCAN() {}
 
-void MegaCAN::processMSreq(uint32_t msgCore, const uint8_t msgData[3], MegaCAN_message_t &msg) {
+void MegaCAN::processMSreq(uint32_t msgCore, const uint8_t msgData[8], MegaCAN_message_t &msg) {
   // Process message core
   msg.core.toTable =   (msgCore & ~(0b11111111111111111111111111111011)) << 2; //set bit 4 of toTable to bit 2 of msgCore
   msg.core.toTable |=  (msgCore & ~(0b11111111111111111111111110000111)) >> 3; //set bits 3-0 of toTable to bits 6-3 of msgCore
@@ -11,8 +11,10 @@ void MegaCAN::processMSreq(uint32_t msgCore, const uint8_t msgData[3], MegaCAN_m
   msg.core.fromID =  (msgCore & ~(0b11111111111111111000011111111111)) >> 11; //set FromID to bits 14-11 of msgCore
   msg.core.msgType = (msgCore & ~(0b11111111111111000111111111111111)) >> 15; //set msgType to bits 17-15 of msgCore
   msg.core.toOffset =  (msgCore & ~(0b11100000000000111111111111111111)) >> 18; //set toOffset to bits 28-18 of msgCore
+	
+  msg.rawData = msgData;	// Don't clobber data for msgType != 1
 
-  // Process message data
+  // Process message data - Only valid if msgType is 1.
   msg.data.request.varBlk = msgData[0];
   msg.data.request.varOffset = msgData[1];
   msg.data.request.varOffset = (msg.data.request.varOffset << 3) | (msgData[2] >> 5);

--- a/MegaCAN.h
+++ b/MegaCAN.h
@@ -21,6 +21,7 @@ typedef struct MegaCAN_message_t {
     } request; //unpacked    
     uint8_t response[8] = { 0 }; // response data bytes back to requester, up to 8 bytes
   } data;  //packed
+  uint8_t rawData[8] = 0;
 } MegaCAN_message_t;
 
 typedef struct MegaCAN_broadcast_message_t {

--- a/MegaCAN.h
+++ b/MegaCAN.h
@@ -21,7 +21,7 @@ typedef struct MegaCAN_message_t {
     } request; //unpacked    
     uint8_t response[8] = { 0 }; // response data bytes back to requester, up to 8 bytes
   } data;  //packed
-  uint8_t rawData[8] = 0;
+  uint8_t rawData[8] = { 0};
 } MegaCAN_message_t;
 
 typedef struct MegaCAN_broadcast_message_t {

--- a/MegaCAN.h
+++ b/MegaCAN.h
@@ -456,7 +456,7 @@ class MegaCAN
 {
   public:
     MegaCAN();
-    void processMSreq(uint32_t msgCore, const uint8_t msgData[3], MegaCAN_message_t &msg);
+    void processMSreq(uint32_t msgCore, const uint8_t msgData[8], MegaCAN_message_t &msg);
     void setMSresp(MegaCAN_message_t recMsg, MegaCAN_message_t &respMsg, uint16_t var0, uint16_t var1, uint16_t var2, uint16_t var3);
 	void getBCastData(uint32_t id, const uint8_t data[8], MegaCAN_broadcast_message_t &msg);
 };


### PR DESCRIPTION
Currently, the library is hard-coded to only handle messages of MSG_REQ, which have a known data length of 3. However, if one is making a device that will accept commands from a Megasquirt, rather than just receiving requests from it, then a data length of up to 8 should be anticipated.

Additionally, since the format of the data in a MSG_CMD message is unknown until it is received, it may be desirable to simply expose the data to the library's user raw. 